### PR TITLE
Add dynamic creature widget

### DIFF
--- a/lib/screens/new_dashboard_screen.dart
+++ b/lib/screens/new_dashboard_screen.dart
@@ -6,6 +6,7 @@ import '../widgets/action_button.dart';
 import '../add_patient_screen.dart';
 import '../search_screen.dart';
 import 'filtered_patients_screen.dart';
+import '../widgets/creature_widget.dart';
 
 class NewDashboardScreen extends StatefulWidget {
   const NewDashboardScreen({Key? key}) : super(key: key);
@@ -639,15 +640,9 @@ class _NewDashboardScreenState extends State<NewDashboardScreen> with SingleTick
           width: 1.0,
         ),
       ),
-      // Добавим текст, чтобы панель была не пустой
-      child: Center(
-        child: Text(
-          'Main Panel (Top)',
-          style: TextStyle(
-            color: Colors.white70,
-            fontSize: isPortrait ? 16 : 18,
-          ),
-        ),
+      // Отображаем динамическое "существо"
+      child: const Center(
+        child: CreatureWidget(),
       ),
     );
   }

--- a/lib/widgets/creature_widget.dart
+++ b/lib/widgets/creature_widget.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Widget that visualizes the "creature" mood depending on today's treatment count.
+class CreatureWidget extends StatelessWidget {
+  const CreatureWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('treatments')
+          .where('date', isEqualTo: Timestamp.fromDate(today))
+          .snapshots(),
+      builder: (context, snapshot) {
+        int count = snapshot.hasData ? snapshot.data!.docs.length : 0;
+
+        IconData icon;
+        Color color;
+        String label;
+
+        if (count <= 5) {
+          icon = Icons.sentiment_satisfied_alt;
+          color = Colors.green;
+          label = 'Спокоен';
+        } else if (count <= 10) {
+          icon = Icons.sentiment_neutral;
+          color = Colors.amber;
+          label = 'Нервничает';
+        } else if (count <= 20) {
+          icon = Icons.sentiment_dissatisfied;
+          color = Colors.orange;
+          label = 'Раздражен';
+        } else {
+          icon = Icons.sentiment_very_dissatisfied;
+          color = Colors.red;
+          label = 'Бешенство';
+        }
+
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: color, size: 80),
+            const SizedBox(height: 8),
+            Text(
+              'Пациентов сегодня: $count',
+              style: const TextStyle(color: Colors.white),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: TextStyle(color: color, fontWeight: FontWeight.bold),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show the new `CreatureWidget` on the main dashboard
- watch today's treatments in Firestore and change the mood icon

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845262537b4832e99531f0be454f72f