### PR TITLE
Allow theming for NotesWidget

### DIFF
--- a/lib/notes_widget.dart
+++ b/lib/notes_widget.dart
@@ -1,10 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'theme/app_theme.dart';
 
 class NotesWidget extends StatefulWidget {
   final String patientId;
+  final Color backgroundColor;
+  final Color textColor;
+  final Color buttonColor;
+  final Color borderColor;
+  final Color boxShadowColor;
 
-  NotesWidget({required this.patientId});
+  NotesWidget({
+    Key? key,
+    required this.patientId,
+    this.backgroundColor = AppTheme.darkCardColor,
+    this.textColor = AppTheme.darkPrimaryTextColor,
+    this.buttonColor = AppTheme.primaryColor,
+    this.borderColor = AppTheme.darkBorderColor,
+    this.boxShadowColor = const Color(0x80000000),
+  }) : super(key: key);
 
   @override
   _NotesWidgetState createState() => _NotesWidgetState();
@@ -56,25 +70,58 @@ class _NotesWidgetState extends State<NotesWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return Container(
       margin: EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: widget.backgroundColor,
+        borderRadius: BorderRadius.circular(12.0),
+        border: Border.all(color: widget.borderColor, width: 1.0),
+        boxShadow: [
+          BoxShadow(
+            color: widget.boxShadowColor,
+            blurRadius: 10,
+            offset: Offset(4, 4),
+          ),
+        ],
+      ),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Примечания', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            Text(
+              'Примечания',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: widget.textColor,
+              ),
+            ),
             SizedBox(height: 8),
             TextField(
               controller: _notesController,
               maxLines: 5,
+              style: TextStyle(color: widget.textColor),
               decoration: InputDecoration(
-                border: OutlineInputBorder(),
+                border: OutlineInputBorder(
+                  borderSide: BorderSide(color: widget.borderColor),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: widget.borderColor),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: widget.buttonColor),
+                ),
                 hintText: 'Введите примечания здесь...',
+                hintStyle: TextStyle(color: widget.textColor.withOpacity(0.6)),
               ),
             ),
             SizedBox(height: 8),
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: widget.buttonColor,
+                foregroundColor: widget.textColor,
+              ),
               onPressed: _saveNotes,
               child: Text('Сохранить примечания'),
             ),


### PR DESCRIPTION
## Summary
- add customizable colors to `NotesWidget`
- style the widget container with border and shadow
- apply the custom colors to text fields and button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453d9ea380832e9c4bc5f44ca3556d